### PR TITLE
Protect output files and harden icon packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ A Windows application that converts images, including HEIC/HEIF formats, to comm
 
 - Drag and drop interface for easy file selection
 - Supports HEIC/HEIF conversion to common formats (including HEIC/HEIF)
+- Automatically avoids overwriting existing output files by appending a number
 - Creates a desktop shortcut for easy access
 - Simple and intuitive user interface
 
 ## Requirements
 
-- Python 3.7 or higher (64-bit recommended for Windows builds)
-- Required Python packages (listed in `requirements.txt` - *Note: Will create requirements.txt later if needed*)
+- Python 3.10 or higher (64-bit recommended for Windows builds)
+- Required Python packages (listed in `requirements.txt`)
   - `Pillow` (for image handling)
   - `pillow-heif` (for HEIC/HEIF support)
   - `tkinterdnd2` (for drag and drop functionality)
@@ -24,14 +25,14 @@ To get a copy of the project up and running on your local machine for developmen
 
 ### Prerequisites
 
-Make sure you have Python installed (3.7+ recommended).
+Make sure you have Python installed (3.10+ recommended).
 
 ### Installation
 
 1. Clone the repository:
    ```bash
    git clone <repository_url>
-   cd bruh-just-convert # Or whatever your repo name is
+   cd your-local-repo-folder
    ```
 
 2. Install the required dependencies. It's recommended to use a virtual environment:
@@ -40,7 +41,7 @@ Make sure you have Python installed (3.7+ recommended).
    .\.venv\Scripts\activate # On Windows
    # source .venv/bin/activate # On macOS/Linux
    
-   pip install -r requirements.txt # Note: Will create requirements.txt later
+   pip install -r requirements.txt
    # OR manually install:
    pip install pillow pillow-heif tkinterdnd2 cx_Freeze
    ```
@@ -55,7 +56,7 @@ build_windows_app.bat
 
 This script automates the build process:
 1. Installs/upgrades required dependencies using pip.
-2. Creates the application icon (`app_icon.ico`).
+2. Creates the application icon assets (`app_icon.png` and `app_icon.ico`).
 3. Builds the standalone executable using `cx_Freeze`.
 4. Creates a desktop shortcut pointing to the executable.
 
@@ -108,4 +109,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Contact
 
-If you have any questions or need assistance, you can reach out via [GitHub Issues](<repository_url>/issues).
+If you have any questions or need assistance, please open an issue in this repository.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,10 @@
-from .gui import ImageConverterApp
-
 __all__ = ["ImageConverterApp"]
+
+
+def __getattr__(name):
+    if name == "ImageConverterApp":
+        from .gui import ImageConverterApp
+
+        return ImageConverterApp
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/app/conversion.py
+++ b/app/conversion.py
@@ -1,10 +1,14 @@
 import os
 from typing import Iterable, Callable, Tuple
 from PIL import Image, UnidentifiedImageError
-import pillow_heif
+try:
+    import pillow_heif
+except ImportError:  # pragma: no cover - exercised only when dependency is absent
+    pillow_heif = None
 
-# Register HEIF/HEIC opener
-pillow_heif.register_heif_opener()
+# Register HEIF/HEIC opener when support is installed
+if pillow_heif is not None:
+    pillow_heif.register_heif_opener()
 
 # Supported output formats (common ones)
 SUPPORTED_OUTPUT_FORMATS = [
@@ -37,6 +41,19 @@ def get_compatible_formats(image_obj: Image.Image) -> list:
     return list(dict.fromkeys(compatible_formats))
 
 
+def get_available_output_path(out_folder: str, base_name: str, output_fmt: str) -> str:
+    """Return a non-conflicting output path for the requested format."""
+    extension = output_fmt.lower()
+    candidate = os.path.join(out_folder, f"{base_name}.{extension}")
+    suffix = 1
+
+    while os.path.exists(candidate):
+        candidate = os.path.join(out_folder, f"{base_name} ({suffix}).{extension}")
+        suffix += 1
+
+    return candidate
+
+
 def convert_images(
     files: Iterable[str],
     output_fmt: str,
@@ -47,8 +64,8 @@ def convert_images(
 
     success_count = 0
     error_count = 0
-    total_files = len(list(files)) if not isinstance(files, list) else len(files)
     files_list = list(files)
+    total_files = len(files_list)
 
     if not os.path.isdir(out_folder):
         try:
@@ -61,10 +78,15 @@ def convert_images(
     for i, file_path in enumerate(files_list):
         filename = os.path.basename(file_path)
         base_name = os.path.splitext(filename)[0]
-        output_filename = f"{base_name}.{output_fmt.lower()}"
-        output_path = os.path.join(out_folder, output_filename)
+        output_path = get_available_output_path(out_folder, base_name, output_fmt)
+        output_filename = os.path.basename(output_path)
         if status_cb:
-            status_cb(f"Converting ({i+1}/{total_files}): {filename}")
+            if output_filename == f"{base_name}.{output_fmt.lower()}":
+                status_cb(f"Converting ({i+1}/{total_files}): {filename}")
+            else:
+                status_cb(
+                    f"Converting ({i+1}/{total_files}): {filename} -> {output_filename}"
+                )
 
         if not os.path.exists(file_path):
             error_count += 1
@@ -74,6 +96,11 @@ def convert_images(
 
         try:
             is_heic = file_path.lower().endswith((".heic", ".heif"))
+            if is_heic and pillow_heif is None:
+                if status_cb:
+                    status_cb(f"Cannot decode HEIC: {filename} (install pillow-heif)")
+                error_count += 1
+                continue
             with Image.open(file_path) as img:
                 try:
                     img.load()

--- a/app/gui.py
+++ b/app/gui.py
@@ -10,13 +10,27 @@ from PIL import Image, UnidentifiedImageError # Pillow for image processing
 import os
 import threading # To keep UI responsive during conversion
 import sys # Needed for theme check
-import pillow_heif # <--- Import pillow-heif to register HEIC support
+try:
+    import pillow_heif  # Import pillow-heif to register HEIC support
+except ImportError:  # pragma: no cover - depends on local install state
+    pillow_heif = None
 
-# Register HEIC/HEIF formats explicitly
-pillow_heif.register_heif_opener()
+# Register HEIC/HEIF formats explicitly when support is installed
+if pillow_heif is not None:
+    pillow_heif.register_heif_opener()
 
 from .conversion import SUPPORTED_OUTPUT_FORMATS, convert_images, get_compatible_formats
 from .thumbnails import update_thumbnails
+
+
+def get_resource_path(filename):
+    """Resolve bundled resources in source and frozen builds."""
+    if getattr(sys, "frozen", False):
+        return os.path.join(os.path.dirname(sys.executable), filename)
+
+    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    return os.path.join(project_root, filename)
+
 
 class ImageConverterApp(TkinterDnD.Tk): # Inherit from TkinterDnD.Tk for DND
 
@@ -29,9 +43,11 @@ class ImageConverterApp(TkinterDnD.Tk): # Inherit from TkinterDnD.Tk for DND
 
         # Add app icon for Windows
         if sys.platform == "win32":
+            icon_path = get_resource_path("app_icon.ico")
             try:
-                self.iconbitmap(default="app_icon.ico")
-            except:
+                if os.path.exists(icon_path):
+                    self.iconbitmap(default=icon_path)
+            except tk.TclError:
                 pass  # Icon not found, continue without it
         
         # --- Data Storage ---

--- a/create_icon.py
+++ b/create_icon.py
@@ -1,7 +1,9 @@
+from pathlib import Path
+
 from PIL import Image, ImageDraw
 
 
-def create_app_icon():
+def create_app_icon(output_dir: str | Path | None = None, output_name: str = "app_icon"):
     # Create a simple image for the icon
     icon_size = (256, 256)
     background_color = (60, 141, 188)  # Blue background
@@ -40,17 +42,22 @@ def create_app_icon():
         fill=(255, 255, 255),
     )
 
+    target_dir = Path(output_dir) if output_dir else Path(__file__).resolve().parent
+    target_dir.mkdir(parents=True, exist_ok=True)
+    png_path = target_dir / f"{output_name}.png"
+    ico_path = target_dir / f"{output_name}.ico"
+
     # Save PNG version of the icon
-    icon_image.save("HEIC_app_icon.png")
+    icon_image.save(png_path)
 
     # Save as ICO file for Windows
     # Resize to multiple icon resolutions required on Windows
     sizes = [(s, s) for s in (16, 32, 48, 64, 128, 256)]
 
     # Save as ICO (Windows icon format)
-    icon_image.save("HEIC_app_icon.ico", format="ICO", sizes=sizes)
+    icon_image.save(ico_path, format="ICO", sizes=sizes)
 
-    print("Icon files created successfully.")
+    print(f"Icon files created successfully: {png_path.name}, {ico_path.name}")
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,14 @@ import sys
 import os
 from cx_Freeze import setup, Executable
 
+ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
+APP_ICON = os.path.join(ROOT_DIR, "app_icon.ico")
+
 # Dependencies - Add more specific package includes for tkinterdnd2
 build_exe_options = {
     "packages": ["tkinter", "PIL", "pillow_heif", "tkinterdnd2", "app"],
     "includes": ["tkinter", "tkinter.ttk", "PIL", "pillow_heif", "tkinterdnd2"],
-    "include_files": ["app_icon.ico"],  # Include the icon file
+    "include_files": [(APP_ICON, "app_icon.ico")] if os.path.exists(APP_ICON) else [],
     "excludes": []
 }
 
@@ -64,10 +67,10 @@ setup(
     },
     executables=[
         Executable(
-            "image_converter.py",
+            os.path.join(ROOT_DIR, "image_converter.py"),
             base=base,
             target_name="SimpleImageConverter.exe",
-            icon="app_icon.ico"  # Will use this icon if it exists
+            icon=APP_ICON if os.path.exists(APP_ICON) else None
         )
     ]
 ) 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,0 +1,69 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from PIL import Image
+
+from app.conversion import convert_images, get_available_output_path
+
+
+def create_image(path: Path, mode: str = "RGBA", color=(255, 0, 0, 255)) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new(mode, (16, 16), color).save(path)
+
+
+class GetAvailableOutputPathTests(unittest.TestCase):
+    def test_appends_suffix_when_target_exists(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            existing = tmp_path / "sample.png"
+            existing.write_bytes(b"existing file")
+
+            output_path = get_available_output_path(tmp_dir, "sample", "PNG")
+
+            self.assertEqual(output_path, str(tmp_path / "sample (1).png"))
+
+
+class ConvertImagesTests(unittest.TestCase):
+    def test_converts_duplicate_basenames_without_overwriting(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            first_source = tmp_path / "first" / "photo.png"
+            second_source = tmp_path / "second" / "photo.png"
+            output_dir = tmp_path / "out"
+
+            create_image(first_source)
+            create_image(second_source, color=(0, 255, 0, 255))
+
+            success_count, error_count = convert_images(
+                [str(first_source), str(second_source)],
+                "JPEG",
+                str(output_dir),
+            )
+
+            self.assertEqual((success_count, error_count), (2, 0))
+            self.assertTrue((output_dir / "photo.jpeg").exists())
+            self.assertTrue((output_dir / "photo (1).jpeg").exists())
+
+    def test_same_format_in_place_creates_numbered_copy(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            source = tmp_path / "photo.png"
+            create_image(source)
+            messages = []
+
+            success_count, error_count = convert_images(
+                [str(source)],
+                "PNG",
+                str(tmp_path),
+                messages.append,
+            )
+
+            self.assertEqual((success_count, error_count), (1, 0))
+            self.assertTrue((tmp_path / "photo.png").exists())
+            self.assertTrue((tmp_path / "photo (1).png").exists())
+            self.assertIn("photo.png -> photo (1).png", messages[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_create_icon.py
+++ b/tests/test_create_icon.py
@@ -1,0 +1,20 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from create_icon import create_app_icon
+
+
+class CreateIconTests(unittest.TestCase):
+    def test_writes_standard_icon_filenames(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            create_app_icon(output_dir=tmp_path)
+
+            self.assertTrue((tmp_path / "app_icon.png").exists())
+            self.assertTrue((tmp_path / "app_icon.ico").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- prevent converted files from overwriting existing outputs by auto-numbering conflicting filenames
- make icon generation/build/runtime lookup agree on `app_icon` assets and use stable project-root paths
- add lightweight tests for conversion naming and icon generation, and decouple package import from the GUI for headless use

## Testing
- `python3 -m unittest discover -s tests -v`
- smoke-tested `create_app_icon()` with a temporary output directory
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0fd4b3d-cff8-4659-8805-8a19cd93fcd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0fd4b3d-cff8-4659-8805-8a19cd93fcd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

